### PR TITLE
PSS-675: Web UI: Send. Token symbol slides out of the border in case of large precision

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soramitsu/soraneo-wallet-web",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "license": "Apache-2.0",
   "private": false,
   "publishConfig": {

--- a/src/components/WalletSend.vue
+++ b/src/components/WalletSend.vue
@@ -389,6 +389,7 @@ $logo-size: var(--s-size-mini);
       &-title {
         line-height: 1.33;
         flex: 1;
+        word-break: break-word;
       }
       &-value {
         .asset {


### PR DESCRIPTION
# Task

[PSS-675]: Web UI: Send. Token symbol slides out of the border in case of large precision

## Changes

* Send dialog: fixed layout for small number.

## Author

Signed-off-by: alexnatalia <alekseenko@soramitsu.co.jp>

[PSS-675]: https://soramitsu.atlassian.net/browse/PSS-675