### PR TITLE
PW-398: Add hide balances functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soramitsu/soraneo-wallet-web",
-  "version": "1.6.13",
+  "version": "1.6.14",
   "license": "Apache-2.0",
   "private": false,
   "publishConfig": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,12 @@
 <template>
-  <s-design-system-provider :value="libraryDesignSystem" id="app">
+  <s-design-system-provider :value="libraryDesignSystem" id="app" class="app-wrapper">
     <s-button class="theme-switch" @click="changeTheme">{{ libraryTheme }} theme</s-button>
     <div class="wallet-wrapper s-flex">
       <sora-wallet />
     </div>
+    <s-button class="hide-balance-switch" @click="toggleHideBalance">
+      {{ shouldBalanceBeHidden ? 'hidden' : 'visible' }} balances
+    </s-button>
   </s-design-system-provider>
 </template>
 
@@ -26,6 +29,9 @@ import { SoraNetwork } from './consts';
   components: { SoraWallet },
 })
 export default class App extends Mixins(TransactionMixin) {
+  @Getter shouldBalanceBeHidden!: boolean;
+  @Action toggleHideBalance!: AsyncVoidFn;
+
   @Getter libraryDesignSystem!: DesignSystem;
   @Getter libraryTheme!: Theme;
   @Getter firstReadyTransaction!: Nullable<History>;
@@ -147,5 +153,14 @@ html {
   justify-content: center;
   align-items: center;
   height: 100vh;
+}
+.app-wrapper {
+  display: flex;
+  justify-content: space-between;
+}
+.theme-switch,
+.hide-balance-switch {
+  width: 185px;
+  margin: 10px;
 }
 </style>

--- a/src/components/FormattedAmount.vue
+++ b/src/components/FormattedAmount.vue
@@ -7,13 +7,16 @@
     ref="parent"
   >
     <span class="formatted-amount__value" ref="child">
-      <span v-if="isFiatValue" class="formatted-amount__prefix">~$</span>
-      <span class="formatted-amount__integer">{{ formatted.integer }}</span>
-      <span v-if="!integerOnly" class="formatted-amount__decimal">
-        <span class="formatted-amount__decimal-value">{{ formatted.decimal }}</span>
-        <span v-if="assetSymbol && symbolAsDecimal" class="formatted-amount__symbol">{{ assetSymbol }}</span>
-      </span>
-      <span v-if="assetSymbol && !symbolAsDecimal" class="formatted-amount__symbol">{{ assetSymbol }}</span>
+      <template v-if="!isBalance || !shouldBalanceBeHidden">
+        <span v-if="isFiatValue" class="formatted-amount__prefix">~$</span>
+        <span class="formatted-amount__integer">{{ formatted.integer }}</span>
+        <span v-if="!integerOnly" class="formatted-amount__decimal">
+          <span class="formatted-amount__decimal-value">{{ formatted.decimal }}</span>
+          <span v-if="assetSymbol && symbolAsDecimal" class="formatted-amount__symbol">{{ assetSymbol }}</span>
+        </span>
+        <span v-if="assetSymbol && !symbolAsDecimal" class="formatted-amount__symbol">{{ assetSymbol }}</span>
+      </template>
+      <span v-else class="formatted-amount__integer">{{ HiddenBalance }}</span>
       <slot />
     </span>
   </span>
@@ -21,9 +24,10 @@
 
 <script lang="ts">
 import { Component, Mixins, Prop } from 'vue-property-decorator';
+import { Getter } from 'vuex-class';
 import { FPNumber } from '@sora-substrate/util';
 
-import { FontSizeRate, FontWeightRate } from '../consts';
+import { FontSizeRate, FontWeightRate, HiddenBalance } from '../consts';
 import NumberFormatterMixin from './mixins/NumberFormatterMixin';
 
 interface FormattedAmountValues {
@@ -33,6 +37,7 @@ interface FormattedAmountValues {
 
 @Component
 export default class FormattedAmount extends Mixins(NumberFormatterMixin) {
+  readonly HiddenBalance = HiddenBalance;
   /**
    * Balance or Amount value.
    */
@@ -61,6 +66,10 @@ export default class FormattedAmount extends Mixins(NumberFormatterMixin) {
    */
   @Prop({ default: false, type: Boolean }) readonly isFiatValue?: boolean;
   /**
+   * Define directly that this field displays account balance which can be hidden.
+   */
+  @Prop({ default: false, type: Boolean }) readonly isBalance?: boolean;
+  /**
    * Fills only intger part if we don't need decimals value.
    */
   @Prop({ default: false, type: Boolean }) readonly integerOnly?: boolean;
@@ -68,6 +77,8 @@ export default class FormattedAmount extends Mixins(NumberFormatterMixin) {
    * Added special class to left shifting for Fiat value if needed (the shift is the same in all screens).
    */
   @Prop({ default: false, type: Boolean }) readonly withLeftShift?: boolean;
+
+  @Getter shouldBalanceBeHidden!: boolean;
 
   isValueWider = false;
 

--- a/src/components/FormattedAmountWithFiatValue.vue
+++ b/src/components/FormattedAmountWithFiatValue.vue
@@ -7,6 +7,7 @@
       :font-weight-rate="fontWeightRate"
       :asset-symbol="assetSymbol"
       :symbol-as-decimal="symbolAsDecimal"
+      :is-balance="isBalance"
     >
       <slot />
     </formatted-amount>
@@ -17,6 +18,7 @@
       :font-size-rate="fiatFormatAsValue ? fontSizeRate : fiatFontSizeRate"
       :font-weight-rate="fiatFormatAsValue ? fontWeightRate : fiatFontWeightRate"
       :with-left-shift="withLeftShift"
+      :is-balance="isBalance"
     />
   </div>
 </template>
@@ -72,6 +74,10 @@ export default class FormattedAmountWithFiatValue extends Vue {
    * We could set this flag to true if we have the same FontSizeRate and FontWeightRate with Amount value.
    */
   @Prop({ default: false, type: Boolean }) readonly fiatFormatAsValue?: boolean;
+  /**
+   * Define directly that this field displays account balance which can be hidden.
+   */
+  @Prop({ default: false, type: Boolean }) readonly isBalance?: boolean;
   /**
    * Fiat value's Font size rate between integer and decimal numbers' parts. Possible values: `"small"`, `"medium"`, `"normal"`.
    * By default it's set to `"normal"` and it means the same font sizes for both numbers' parts.

--- a/src/components/WalletAssetDetails.vue
+++ b/src/components/WalletAssetDetails.vue
@@ -16,18 +16,20 @@
         <i class="asset-logo" :style="getAssetIconStyles(asset.address)" />
         <div :style="balanceStyles" :class="balanceDetailsClasses" @click="isXor && handleClickDetailedBalance()">
           <formatted-amount
+            is-balance
+            symbol-as-decimal
             :value="balance"
             :font-size-rate="FontSizeRate.SMALL"
             :asset-symbol="asset.symbol"
-            symbol-as-decimal
           >
             <s-icon v-if="isXor" name="chevron-down-rounded-16" size="18" />
           </formatted-amount>
         </div>
         <formatted-amount
           v-if="price"
-          :value="getFiatBalance(asset)"
+          is-balance
           is-fiat-value
+          :value="getFiatBalance(asset)"
           :font-size-rate="FontSizeRate.MEDIUM"
         />
         <div class="asset-details-actions">
@@ -45,34 +47,42 @@
             <s-icon :name="operation.icon" size="28" />
           </s-button>
         </div>
-        <div v-if="isXor && wasBalanceDetailsClicked" class="asset-details-balance-info">
-          <div v-for="type in balanceTypes" :key="type" class="balance s-flex p4">
-            <div class="balance-label">{{ t(`assets.balance.${type}`) }}</div>
-            <formatted-amount-with-fiat-value
-              value-class="balance-value"
-              :value="formatBalance(asset.balance[type])"
-              :font-size-rate="FontSizeRate.MEDIUM"
-              :font-weight-rate="FontWeightRate.SMALL"
-              :asset-symbol="asset.symbol"
-              :fiat-value="getFiatBalance(asset, type)"
-              fiat-format-as-value
-              with-left-shift
-            />
+        <transition name="fadeHeight">
+          <div
+            key="asset-details-balance-info"
+            v-if="isXor && wasBalanceDetailsClicked"
+            class="asset-details-balance-info"
+          >
+            <div v-for="type in balanceTypes" :key="type" class="balance s-flex p4">
+              <div class="balance-label">{{ t(`assets.balance.${type}`) }}</div>
+              <formatted-amount-with-fiat-value
+                is-balance
+                value-class="balance-value"
+                :value="formatBalance(asset.balance[type])"
+                :font-size-rate="FontSizeRate.MEDIUM"
+                :font-weight-rate="FontWeightRate.SMALL"
+                :asset-symbol="asset.symbol"
+                :fiat-value="getFiatBalance(asset, type)"
+                fiat-format-as-value
+                with-left-shift
+              />
+            </div>
+            <div class="balance s-flex p4">
+              <div class="balance-label balance-label--total">{{ t('assets.balance.total') }}</div>
+              <formatted-amount-with-fiat-value
+                is-balance
+                value-class="balance-value"
+                :value="totalBalance"
+                :font-size-rate="FontSizeRate.MEDIUM"
+                :font-weight-rate="FontWeightRate.SMALL"
+                :asset-symbol="asset.symbol"
+                :fiat-value="getFiatBalance(asset, BalanceType.Total)"
+                fiat-format-as-value
+                with-left-shift
+              />
+            </div>
           </div>
-          <div class="balance s-flex p4">
-            <div class="balance-label balance-label--total">{{ t('assets.balance.total') }}</div>
-            <formatted-amount-with-fiat-value
-              value-class="balance-value"
-              :value="totalBalance"
-              :font-size-rate="FontSizeRate.MEDIUM"
-              :font-weight-rate="FontWeightRate.SMALL"
-              :asset-symbol="asset.symbol"
-              :fiat-value="getFiatBalance(asset, BalanceType.Total)"
-              fiat-format-as-value
-              with-left-shift
-            />
-          </div>
-        </div>
+        </transition>
       </div>
     </s-card>
     <wallet-history :asset="asset" />
@@ -91,7 +101,7 @@ import WalletBase from './WalletBase.vue';
 import FormattedAmount from './FormattedAmount.vue';
 import FormattedAmountWithFiatValue from './FormattedAmountWithFiatValue.vue';
 import WalletHistory from './WalletHistory.vue';
-import { RouteNames, FontSizeRate, FontWeightRate } from '../consts';
+import { RouteNames } from '../consts';
 import { getAssetIconStyles } from '../util';
 import { Operations, Account } from '../types/common';
 
@@ -119,8 +129,6 @@ export default class WalletAssetDetails extends Mixins(FormattedAmountMixin, Cop
   ] as Array<Operation>;
 
   readonly BalanceType = BalanceType;
-  readonly FontSizeRate = FontSizeRate;
-  readonly FontWeightRate = FontWeightRate;
 
   @Getter account!: Account;
   @Getter accountAssets!: Array<AccountAsset>;
@@ -260,6 +268,7 @@ export default class WalletAssetDetails extends Mixins(FormattedAmountMixin, Cop
   &-container {
     flex-direction: column;
     align-items: center;
+    @include fadeHeight;
     .formatted-amount--fiat-value {
       + .asset-details-actions {
         margin-top: #{$basic-spacing-small};

--- a/src/components/WalletAssets.vue
+++ b/src/components/WalletAssets.vue
@@ -3,7 +3,7 @@
     <template v-if="assetsFiatAmount">
       <div class="total-fiat-values">
         <span class="total-fiat-values__title">{{ t('assets.totalAssetsValue') }}</span>
-        <formatted-amount :value="assetsFiatAmount" is-fiat-value integer-only with-left-shift />
+        <formatted-amount is-balance is-fiat-value integer-only with-left-shift :value="assetsFiatAmount" />
       </div>
       <s-divider class="wallet-assets-item_divider" />
     </template>
@@ -14,6 +14,7 @@
             <i class="asset-logo" :style="getAssetIconStyles(asset.address)" />
             <div class="asset s-flex">
               <formatted-amount-with-fiat-value
+                is-balance
                 value-class="asset-value"
                 :value="getBalance(asset)"
                 :font-size-rate="FontSizeRate.SMALL"
@@ -95,7 +96,7 @@ import LoadingMixin from './mixins/LoadingMixin';
 import CopyAddressMixin from './mixins/CopyAddressMixin';
 import FormattedAmount from './FormattedAmount.vue';
 import FormattedAmountWithFiatValue from './FormattedAmountWithFiatValue.vue';
-import { RouteNames, WalletPermissions, FontSizeRate, FontWeightRate } from '../consts';
+import { RouteNames, WalletPermissions, HiddenBalance } from '../consts';
 import { getAssetIconStyles, formatAddress } from '../util';
 
 @Component({
@@ -105,12 +106,10 @@ import { getAssetIconStyles, formatAddress } from '../util';
   },
 })
 export default class WalletAssets extends Mixins(LoadingMixin, FormattedAmountMixin, CopyAddressMixin) {
-  readonly FontSizeRate = FontSizeRate;
-  readonly FontWeightRate = FontWeightRate;
-
   @Getter accountAssets!: Array<AccountAsset>;
   @Getter withoutFiatAndApy!: boolean;
   @Getter permissions!: WalletPermissions;
+  @Getter shouldBalanceBeHidden!: boolean;
   @Action getAccountAssets!: AsyncVoidFn;
   @Action navigate!: (options: { name: string; params?: object }) => Promise<void>;
 
@@ -170,6 +169,9 @@ export default class WalletAssets extends Mixins(LoadingMixin, FormattedAmountMi
   }
 
   formatFrozenBalance(asset: AccountAsset): string {
+    if (this.shouldBalanceBeHidden) {
+      return HiddenBalance;
+    }
     return this.formatCodecNumber(asset.balance.frozen, asset.decimals);
   }
 

--- a/src/components/WalletSend.vue
+++ b/src/components/WalletSend.vue
@@ -34,8 +34,17 @@
             <div class="wallet-send-amount-title">{{ t('walletSend.amount') }}</div>
             <div class="wallet-send-amount-balance">
               <span class="wallet-send-amount-balance-title">{{ t('walletSend.balance') }}</span>
-              <span class="wallet-send-amount-balance-value">{{ balance }}</span>
-              <formatted-amount v-if="assetFiatPrice" :value="getFiatBalance(asset)" is-fiat-value with-left-shift />
+              <formatted-amount-with-fiat-value
+                is-balance
+                fiat-format-as-value
+                with-left-shift
+                value-class="wallet-send-amount-balance-value"
+                :value="balance"
+                :font-size-rate="FontSizeRate.MEDIUM"
+                :font-weight-rate="FontWeightRate.SMALL"
+                :asset-symbol="asset.symbol"
+                :fiat-value="getFiatBalance(asset)"
+              />
             </div>
           </div>
           <div class="asset s-flex" slot="right">
@@ -121,16 +130,17 @@ import FormattedAmountMixin from './mixins/FormattedAmountMixin';
 import CopyAddressMixin from './mixins/CopyAddressMixin';
 import WalletBase from './WalletBase.vue';
 import FormattedAmount from './FormattedAmount.vue';
+import FormattedAmountWithFiatValue from './FormattedAmountWithFiatValue.vue';
 import WalletFee from './WalletFee.vue';
 import { RouteNames } from '../consts';
 import { formatAddress, formatSoraAddress, getAssetIconStyles } from '../util';
 import { api } from '../api';
-import type { Account } from '../types/common';
 
 @Component({
   components: {
     WalletBase,
     FormattedAmount,
+    FormattedAmountWithFiatValue,
     WalletFee,
   },
 })
@@ -138,7 +148,6 @@ export default class WalletSend extends Mixins(TransactionMixin, FormattedAmount
   readonly delimiters = FPNumber.DELIMITERS_CONFIG;
 
   @Getter currentRouteParams!: any;
-  @Getter account!: Account;
   @Getter accountAssets!: Array<AccountAsset>;
   @Getter networkFees!: NetworkFeesObject;
 

--- a/src/components/mixins/FormattedAmountMixin.ts
+++ b/src/components/mixins/FormattedAmountMixin.ts
@@ -12,9 +12,13 @@ import {
 
 import NumberFormatterMixin from './NumberFormatterMixin';
 import { FiatPriceAndApyObject } from '../../services/types';
+import { FontSizeRate, FontWeightRate } from '../../consts';
 
 @Component
 export default class FormattedAmountMixin extends Mixins(NumberFormatterMixin) {
+  readonly FontSizeRate = FontSizeRate;
+  readonly FontWeightRate = FontWeightRate;
+
   @Getter fiatPriceAndApyObject!: FiatPriceAndApyObject;
 
   getAssetFiatPrice(accountAsset: Asset | AccountAsset): Nullable<CodecString> {

--- a/src/consts/index.ts
+++ b/src/consts/index.ts
@@ -63,3 +63,5 @@ export enum FontWeightRate {
   MEDIUM = 'medium',
   NORMAL = 'normal',
 }
+
+export const HiddenBalance = '******';

--- a/src/store/Account.ts
+++ b/src/store/Account.ts
@@ -74,7 +74,7 @@ function initialState(): AccountState {
   return {
     address: storage.get('address') || '',
     name: storage.get('name') || '',
-    isExternal: Boolean(storage.get('isExternal')) || false,
+    isExternal: Boolean(JSON.parse(storage.get('isExternal'))) || false,
     accountAssets: [],
     selectedTransactionId: null,
     activity: [], // account history (without bridge)

--- a/src/store/Settings.ts
+++ b/src/store/Settings.ts
@@ -7,6 +7,7 @@ import type { NetworkFeesObject } from '@sora-substrate/util';
 
 import { api } from '../api';
 import type { WalletPermissions, SoraNetwork } from '../consts';
+import { storage } from '../util/storage';
 
 const types = flow(
   flatMap((x) => [x + '_REQUEST', x + '_SUCCESS', x + '_FAILURE']),
@@ -30,7 +31,7 @@ function initialState(): SettingsState {
     },
     soraNetwork: null,
     networkFees: {} as NetworkFeesObject, // It won't be empty at the moment of usage
-    shouldBalanceBeHidden: false,
+    shouldBalanceBeHidden: Boolean(JSON.parse(storage.get('shouldBalanceBeHidden'))) || false,
   };
 }
 
@@ -70,6 +71,7 @@ const mutations = {
 
   [types.TOGGLE_HIDE_BALANCE](state: SettingsState) {
     state.shouldBalanceBeHidden = !state.shouldBalanceBeHidden;
+    storage.set('shouldBalanceBeHidden', state.shouldBalanceBeHidden);
   },
 };
 

--- a/src/store/Settings.ts
+++ b/src/store/Settings.ts
@@ -10,7 +10,7 @@ import type { WalletPermissions, SoraNetwork } from '../consts';
 
 const types = flow(
   flatMap((x) => [x + '_REQUEST', x + '_SUCCESS', x + '_FAILURE']),
-  concat(['SET_PERMISSIONS', 'SET_SORA_NETWORK', 'UPDATE_NETWORK_FEES']),
+  concat(['SET_PERMISSIONS', 'SET_SORA_NETWORK', 'UPDATE_NETWORK_FEES', 'TOGGLE_HIDE_BALANCE']),
   map((x) => [x, x]),
   fromPairs
 )([]);
@@ -19,6 +19,7 @@ type SettingsState = {
   permissions: WalletPermissions;
   soraNetwork: Nullable<SoraNetwork>;
   networkFees: NetworkFeesObject;
+  shouldBalanceBeHidden: boolean;
 };
 
 function initialState(): SettingsState {
@@ -29,6 +30,7 @@ function initialState(): SettingsState {
     },
     soraNetwork: null,
     networkFees: {} as NetworkFeesObject, // It won't be empty at the moment of usage
+    shouldBalanceBeHidden: false,
   };
 }
 
@@ -43,6 +45,9 @@ const getters = {
   },
   networkFees(state: SettingsState): NetworkFeesObject {
     return state.networkFees;
+  },
+  shouldBalanceBeHidden(state: SettingsState): boolean {
+    return state.shouldBalanceBeHidden;
   },
 };
 
@@ -62,6 +67,10 @@ const mutations = {
   [types.UPDATE_NETWORK_FEES](state: SettingsState, fees = {} as NetworkFeesObject) {
     state.networkFees = { ...fees };
   },
+
+  [types.TOGGLE_HIDE_BALANCE](state: SettingsState) {
+    state.shouldBalanceBeHidden = !state.shouldBalanceBeHidden;
+  },
 };
 
 const actions = {
@@ -75,6 +84,10 @@ const actions = {
 
   updateNetworkFees({ commit }) {
     commit(types.UPDATE_NETWORK_FEES, api.NetworkFee);
+  },
+
+  toggleHideBalance({ commit }) {
+    commit(types.TOGGLE_HIDE_BALANCE);
   },
 };
 

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -171,3 +171,17 @@
     }
   }
 }
+
+@mixin fadeHeight ($seconds: .3s) {
+  .fadeHeight-enter-active,
+  .fadeHeight-leave-active {
+    transition: all $seconds;
+    max-height: 200px;
+  }
+  .fadeHeight-enter,
+  .fadeHeight-leave-to
+  {
+    opacity: 0;
+    max-height: 0px;
+  }
+}


### PR DESCRIPTION
<h1>Description</h1>
<p>Since vue filters were removed from vue3, I've made a decision just to use an additional property for all balances.</p>

<h1>Works done</h1>

- [x] Added hide balance functionality
- [x] Added animation for asset details
- [x] Some styles were fixed
- [ ] Tests were updated