### PR TITLE
[DialogBase] Update dialog top property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soramitsu/soraneo-wallet-web",
-  "version": "1.40.14",
+  "version": "1.40.15",
   "license": "Apache-2.0",
   "private": false,
   "publishConfig": {

--- a/src/components/DialogBase.vue
+++ b/src/components/DialogBase.vue
@@ -116,7 +116,9 @@ export default class DialogBase extends Mixins(DialogMixin) {
   @Ref('dialog') readonly dialogCmp!: SDialog;
 
   @Watch('isVisible')
-  private onVisibilityUpdate(value: boolean) {
+  private async onVisibilityUpdate(value: boolean) {
+    // wait for vdom update (imported async components loading)
+    await this.$nextTick();
     if (value) {
       this.createContentObserver();
     } else {


### PR DESCRIPTION
### **Description**
- **What does this PR do?**
  - Added ResizeObserver to DialogBase content. When content size is changed - computeTop method is calling to align dialog position on the screen
  
- **Why is this change needed?**
  - When dialog content changes height, we should align dialog modal on screen. Otherwise it may be pressed to the bottom of the screen

### **Type of change**
- [ ] Bug fix
- [x] New feature
- [x] Refactor (cleaning up code without changing functionality)
- [ ] Documentation update
- [ ] Tests
- [ ] Other (describe below):

---

### **Checklist**
- [ ] Code adheres to coding guidelines and standards.
- [ ] Linting and formatting checks have passed, no local issues.
- [ ] Existing tests pass successfully, no local errors.
- [ ] Pull request is linked to a relevant issue or task.
- [ ] Tests are written for new features or fixes.
- [ ] Documentation has been updated (if applicable).
  
---

### **Related Issue/Task**
- Issue/Task link: [[Dialog] Update Dialog top property depends on content height](https://soramitsu.atlassian.net/browse/PW-1749)

---

### **Testing**
- **How has this been tested?**
  - _Describe manual testing steps or link to relevant automated tests._
  
- **Edge cases covered:**
  - _List any specific cases handled by this PR._

---

### **Screenshots/Video/Link to dedicated environment (if applicable)**
- _Include any visual examples of the change + dedicated environment (if there is a sort of automation)._

---

### **Additional Notes**
- _Add any information the reviewer should consider, especially cross-project impacts, UX changes, or potential risks._

---

### **Reviewer Tasks**
- [x] Review logic for correctness and clarity.
- [x] Verify that the code is following best practices.
- [ ] Test or review related areas if this PR affects other projects.
